### PR TITLE
Facade alias would cause duplicate imports for global aliases

### DIFF
--- a/src/Tasks/FacadeAliases.php
+++ b/src/Tasks/FacadeAliases.php
@@ -132,7 +132,7 @@ class FacadeAliases implements Task
                 $prefix .= 'Facades\\';
             }
 
-            if (str_contains('use ' . $prefix . $import . ';', $contents)) {
+            if (str_contains($contents, 'use ' . $prefix . $import . ';')) {
                 continue;
             }
 

--- a/tests/fixtures/facade-aliases/complex.after.php
+++ b/tests/fixtures/facade-aliases/complex.after.php
@@ -27,6 +27,12 @@ class ComplexClass
         Another\Arr::wrap('arr');
     }
 
+    public function duplicates()
+    {
+        Arr::wrap('arr');
+        Arr::wrap('arr');
+    }
+
     public function duplicateGlobals()
     {
         App::make('app');

--- a/tests/fixtures/facade-aliases/complex.after.php
+++ b/tests/fixtures/facade-aliases/complex.after.php
@@ -26,4 +26,10 @@ class ComplexClass
         SomeApp::make('app');
         Another\Arr::wrap('arr');
     }
+
+    public function duplicateGlobals()
+    {
+        App::make('app');
+        App::make('app');
+    }
 }

--- a/tests/fixtures/facade-aliases/complex.php
+++ b/tests/fixtures/facade-aliases/complex.php
@@ -25,6 +25,12 @@ class ComplexClass
         Another\Arr::wrap('arr');
     }
 
+    public function duplicates()
+    {
+        Arr::wrap('arr');
+        Arr::wrap('arr');
+    }
+
     public function duplicateGlobals()
     {
         \App::make('app');

--- a/tests/fixtures/facade-aliases/complex.php
+++ b/tests/fixtures/facade-aliases/complex.php
@@ -24,4 +24,10 @@ class ComplexClass
         SomeApp::make('app');
         Another\Arr::wrap('arr');
     }
+
+    public function duplicateGlobals()
+    {
+        \App::make('app');
+        \App::make('app');
+    }
 }


### PR DESCRIPTION
- 5440708 Failing test that show that imports are duplicated if there is more than one of the same global class
- 46a2832 fix `str_contains` parameter order to fix duplicate imports
- f389331 add additional test for duplicate normal items for better coverage to prove that still works.