### PR TITLE
- Fix AnonymousMigrations parsing for } beyond the class declaration

### DIFF
--- a/src/Tasks/AnonymousMigrations.php
+++ b/src/Tasks/AnonymousMigrations.php
@@ -2,7 +2,6 @@
 
 namespace Shift\Cli\Tasks;
 
-use Illuminate\Support\Str;
 use Shift\Cli\Sdk\Contracts\Task;
 use Shift\Cli\Sdk\Models\File;
 use Shift\Cli\Sdk\Traits\FindsFiles;
@@ -94,9 +93,9 @@ class AnonymousMigrations implements Task
         if (! $found) {
             return null;
         }
-        $contents = \substr_replace( $contents,
+        $contents = \substr_replace($contents,
             ';',
-            $class['offset']['end'] +1 ,
+            $class['offset']['end'] + 1,
             0
         );
 

--- a/src/Tasks/AnonymousMigrations.php
+++ b/src/Tasks/AnonymousMigrations.php
@@ -4,6 +4,7 @@ namespace Shift\Cli\Tasks;
 
 use Illuminate\Support\Str;
 use Shift\Cli\Sdk\Contracts\Task;
+use Shift\Cli\Sdk\Models\File;
 use Shift\Cli\Sdk\Traits\FindsFiles;
 
 class AnonymousMigrations implements Task
@@ -20,6 +21,15 @@ class AnonymousMigrations implements Task
         $this->updateStubs();
 
         return 0;
+    }
+
+    private function parseClass(string $contents)
+    {
+        static $finder;
+
+        $finder ??= new \Shift\Cli\Sdk\Parsers\NikicParser(new \Shift\Cli\Sdk\Parsers\Finders\ClassDefinition());
+
+        return $finder->parse($contents);
     }
 
     private function updateMigrations(): void
@@ -77,14 +87,22 @@ class AnonymousMigrations implements Task
 
     private function convertClassDefinition($contents): ?string
     {
+        $file = File::fromString($contents);
+        $class = $this->parseClass($file->contents());
+
         $found = \preg_match('/^class\s+(\S+)\s+extends\s+Migration(\s+)/m', $contents, $matches);
         if (! $found) {
             return null;
         }
+        $contents = \substr_replace( $contents,
+            ';',
+            $class['offset']['end'] +1 ,
+            0
+        );
 
         $contents = \str_replace(\rtrim($matches[0]), 'return new class extends Migration', $contents);
         $contents = \preg_replace('/\b' . \preg_quote($matches[1], '/') . '::/', 'self::', $contents);
 
-        return Str::replaceLast('}', '};', $contents);
+        return $contents;
     }
 }

--- a/tests/Feature/Tasks/AnonymousMigrationsTest.php
+++ b/tests/Feature/Tasks/AnonymousMigrationsTest.php
@@ -54,4 +54,18 @@ class AnonymousMigrationsTest extends TestCase
         $this->assertFileChanges('tests/fixtures/anonymous-migrations/simple.after.php', 'other/migrations/2014_10_12_000000_create_users_table.php');
         $this->assertFileChanges('tests/fixtures/anonymous-migrations/stub.after.php', 'stubs/migration.stub');
     }
+
+    #[Test]
+    public function it_converts_with_comments_beyond_the_class()
+    {
+        $this->fakeProject([
+            'database/migrations/2015_10_12_000000_create_users_table.php' => 'tests/fixtures/anonymous-migrations/post-class-comments.php',
+        ]);
+
+        $result = $this->subject->perform();
+
+        $this->assertSame(0, $result);
+
+        $this->assertFileChanges('tests/fixtures/anonymous-migrations/post-class-comments.after.php', 'database/migrations/2015_10_12_000000_create_users_table.php');
+    }
 }

--- a/tests/fixtures/anonymous-migrations/post-class-comments.after.php
+++ b/tests/fixtures/anonymous-migrations/post-class-comments.after.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('videos', function (Blueprint $table) {
+            $table->integer('runtime')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('videos', function (Blueprint $table) {
+            $table->dropColumn('runtime');
+        });
+    }
+};
+
+/* a closing bracket in a comment here can confuse the parsing
+{ id: 1, name: "Doug" }
+*/

--- a/tests/fixtures/anonymous-migrations/post-class-comments.php
+++ b/tests/fixtures/anonymous-migrations/post-class-comments.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class PostClassComments extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('videos', function (Blueprint $table) {
+            $table->integer('runtime')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('videos', function (Blueprint $table) {
+            $table->dropColumn('runtime');
+        });
+    }
+}
+
+/* a closing bracket in a comment here can confuse the parsing
+{ id: 1, name: "Doug" }
+*/


### PR DESCRIPTION
In the AnonymousMigrations task the closing ; will appear in the wrong location if `}` appears after the class (in a comment section for example), as reported in issue #10 .

In this PR, we parse the class to determine where the declaration ends, then insert a `;`  
This is similar to what happens in the DownMigration task.
